### PR TITLE
Fix #21, #33, #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ After launching, navigate to `localhost:9090/r/{subreddit}`, and you're done.
 </details>
 
 <details>
+<summary>Advanced Math Enabled</summary>
+
+| Chrome | Edge | Safari | Firefox | Opera | IE |
+|:------:|:----:|:------:|:-------:|:-----:|:--:|
+| 79>    | 79>  | 13.1>  | 75>     | 66>   | X  |
+
+</details>
+
+<details>
 <summary>Legend</summary>
 
 `>` -> Any equal, or newer version is supported

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/goccy/go-json v0.10.2
-	github.com/gofiber/fiber/v2 v2.43.0
+	github.com/gofiber/fiber/v2 v2.44.0
 	github.com/gofiber/helmet/v2 v2.2.25
 	github.com/gofiber/template v1.8.0
 	github.com/microcosm-cc/bluemonday v1.0.23

--- a/src/go.sum
+++ b/src/go.sum
@@ -132,8 +132,9 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofiber/fiber/v2 v2.43.0 h1:yit3E4kHf178B60p5CQBa/3v+WVuziWMa/G2ZNyLJB0=
 github.com/gofiber/fiber/v2 v2.43.0/go.mod h1:mpS1ZNE5jU+u+BA4FbM+KKnUzJ4wzTK+FT2tG3tU+6I=
+github.com/gofiber/fiber/v2 v2.44.0 h1:Z90bEvPcJM5GFJnu1py0E1ojoerkyew3iiNJ78MQCM8=
+github.com/gofiber/fiber/v2 v2.44.0/go.mod h1:VTMtb/au8g01iqvHyaCzftuM/xmZgKOZCtFzz6CdV9w=
 github.com/gofiber/helmet/v2 v2.2.25 h1:PC90SBQQ/tzcDUGJtTHAIftdLMa6ylICUCUiM6qzU9s=
 github.com/gofiber/helmet/v2 v2.2.25/go.mod h1:3cn2RTs4wU4QEjwxM8dMwHiZprgJjeIvVGntP16Et1Y=
 github.com/gofiber/template v1.8.0 h1:jOn9RhxYO7rHTHGLNRpYfDoVm8b5GH/dtl15ZT5NifE=

--- a/src/logic/logic.go
+++ b/src/logic/logic.go
@@ -1,34 +1,30 @@
 package logic
 
 import (
-	"crypto/tls"
 	"fmt"
 	"log"
 	"main/logic/types"
 	"net/http"
 
 	"github.com/goccy/go-json"
-)
-
-var (
-	Client = http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{},
-		},
-	}
+	"github.com/gofiber/fiber/v2/utils"
 )
 
 func GetSubredditData(subreddit string) types.Subreddit {
-	url := fmt.Sprintf("https://reddit.com/r/%v/about.json?raw_json=1", subreddit)
+	url := fmt.Sprintf("https://www.reddit.com/r/%v/about.json?raw_json=1", subreddit)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		log.Println(err)
 	}
 
-	req.Header.Set("User-Agent", "go:lex:cmd777")
+	req.Header.Set("User-Agent", "go:lex:cmd777-with-"+utils.UUIDv4())
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Host", "www.reddit.com")
 
-	resp, err := Client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Println(err)
 	}
@@ -46,7 +42,7 @@ func GetSubredditData(subreddit string) types.Subreddit {
 }
 
 func GetPosts(subreddit string, after string, flair string) types.Posts {
-	url := fmt.Sprintf("https://reddit.com/r/%v", subreddit)
+	url := fmt.Sprintf("https://www.reddit.com/r/%v", subreddit)
 	if len(flair) != 0 {
 		// stupid.
 		// https://www.reddit.com/r/ModSupport/comments/hpf6na/filtering_by_flair_broken_for_some_users_on/
@@ -64,9 +60,13 @@ func GetPosts(subreddit string, after string, flair string) types.Posts {
 		log.Println(err)
 	}
 
-	req.Header.Set("User-Agent", "go:lex:cmd777")
+	req.Header.Set("User-Agent", "go:lex:cmd777-with-"+utils.UUIDv4())
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Host", "www.reddit.com")
 
-	resp, err := Client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Println(err)
 	}

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -36,6 +36,7 @@ const (
 	ResCookie     = "PreferredResolution"
 	GalleryCookie = "GalleryNav"
 	USRCCookie    = "TrustUSrc"
+	MathCookie    = "UseAdvMath"
 
 	JSCookieValue      = "js_enabled"
 	INFCookieValue     = "infscroll_enabled"
@@ -43,6 +44,7 @@ const (
 	ResCookieValue     = "preferred_resolution"
 	GalleryCookieValue = "gallery_navigation"
 	USRCCookieValue    = "trust_unknownsources"
+	MathCookieValue    = "advanced_math"
 )
 
 var (
@@ -55,6 +57,7 @@ var (
 		"PrefRes":          ResCookieValue,
 		"EnableGalleryNav": GalleryCookieValue,
 		"TrustUnknownSrc":  USRCCookieValue,
+		"UseAdvancedMath":  MathCookieValue,
 	}
 
 	ValidImageExts = map[string]bool{
@@ -134,6 +137,7 @@ func StartServer() {
 			nsfwallowed := ctx.Cookies(NSFWCookieValue)
 			gallerynav := ctx.Cookies(GalleryCookieValue)
 			trustusrc := ctx.Cookies(USRCCookieValue)
+			advmath := ctx.Cookies(MathCookieValue)
 
 			ctx.Bind(fiber.Map{ //nolint:errcheck // ctx.Bind always returns nil
 				JSCookie:      jsenabled == "1",
@@ -141,6 +145,7 @@ func StartServer() {
 				NSFWCookie:    nsfwallowed == "1",
 				GalleryCookie: gallerynav == "1",
 				USRCCookie:    trustusrc == "1",
+				MathCookie:    advmath == "1",
 			})
 
 			return ctx.Next()

--- a/src/views/config.html
+++ b/src/views/config.html
@@ -82,6 +82,20 @@
             </pre>
 
             <label>
+                <input type="checkbox" name="UseAdvancedMath" {{if .UseAdvMath}} checked {{end}}>
+                <input type="hidden" name="UseAdvancedMath" value="off">
+                Use Advanced Math (CSS) (Viewport Sizing)
+            </label>
+            <pre>
+                PROS:
+                Uses clamp to size posts, images
+
+                CONS:
+                Requires newer browsers (see in the github compatability section)
+                May impact performance
+            </pre>
+
+            <label>
                 Preferred Resolution
                 <select name="PrefRes">
                     <!-- dear lord -->

--- a/src/views/posts.html
+++ b/src/views/posts.html
@@ -42,11 +42,11 @@
                 {{range .Data.Awardings}}
                     {{if contains .AwardSubType "MODERATOR"}}
                         <span style="padding-left: 5px;">
-                            <img class="malign" width="16" height="16" src="{{(index .ResizedIcons 0).URL}}"> {{.Name}}
+                            <img class="malign" width="16" height="16" src="{{(index .ResizedIcons 0).URL|sterilizepath}}"> {{.Name}}
                         </span>
                     {{else}}
                         <span style="padding-left: 5px;">
-                            <img class="malign" width="16" height="16" src="{{(index .ResizedIcons 0).URL}}">
+                            <img class="malign" width="16" height="16" src="{{(index .ResizedIcons 0).URL|sterilizepath}}">
                             {{if gt .Count 1}}
                                 {{.Count}}
                             {{end}}
@@ -85,9 +85,9 @@
                             <video preload="none" poster="{{.Data.Preview.AutoChosenPosterQuality}}" controls loop>
                                 <source src="
                                 {{if and ($.JSEnabled) (.Data.Preview.RedditVideoPreview.HLSURL)}}
-                                    {{.Data.Preview.RedditVideoPreview.HLSURL}}
+                                    {{.Data.Preview.RedditVideoPreview.HLSURL|sterilizepath}}
                                 {{else if .Data.Preview.RedditVideoPreview.FallbackURL}}
-                                    {{.Data.Preview.RedditVideoPreview.FallbackURL}}
+                                    {{.Data.Preview.RedditVideoPreview.FallbackURL|sterilizepath}}
                                 {{else}}
                                     {{.Data.Preview.AutoChosenImageQuality}}
                                 {{end}}">
@@ -143,9 +143,9 @@
                         <video preload="none" poster="{{.Data.Preview.AutoChosenPosterQuality}}" controls>
                             <source src="
                             {{if and ($.JSEnabled) (.Data.SecureMedia.RedditVideo.HLSURL)}}
-                                {{.Data.SecureMedia.RedditVideo.HLSURL}}
+                                {{.Data.SecureMedia.RedditVideo.HLSURL|sterilizepath}}
                             {{else}}
-                                {{.Data.SecureMedia.RedditVideo.FallbackURL}}
+                                {{.Data.SecureMedia.RedditVideo.FallbackURL|sterilizepath}}
                             {{end}}">
                         </video>
                     </div>
@@ -206,7 +206,7 @@
 
             {{if .Data.Preview.AutoChosenImageQuality}}
                 {{if (index .Data.Preview.Images 0).Variants.GIF.Source.URL}}
-                <a href="{{(index .Data.Preview.Images 0).Variants.GIF.Source.URL}}" class="l-hovergray" rel="noreferrer noopener nofollow">
+                <a href="{{(index .Data.Preview.Images 0).Variants.GIF.Source.URL|sterilizepath}}" class="l-hovergray" rel="noreferrer noopener nofollow">
                     <svg width="16" height="16" viewBox="0 0 24 24" version="1.1" class="gicon">
                         <path fill-rule="evenodd" d="M21.7092 2.295C21.8041 2.3904 21.8757 2.5001 21.9241 2.6172 21.9727 2.7342 21.9996 2.8625 22 2.997L22 3V9C22 9.5523 21.5523 10 21 10 20.4477 10 20 9.5523 20 9V5.4142L14.7071 10.7071C14 10 14 10 13.2929 9.2929L18.5858 4H15C14.4477 4 14 3.5523 14 3 14 2.4477 14.4477 2 15 2H20.9998C21.2749 2 21.5242 2.1111 21.705 2.2908L21.7092 2.295M14.709 10.707 5.4142 20H9C9.5523 20 10 20.4477 10 21 10 21.5523 9.5523 22 9 22H3.0007L2.997 22C2.743 21.9992 2.4892 21.9023 2.295 21.7092L2.2908 21.705C2.1959 21.6096 2.1243 21.4999 2.0759 21.3828 2.027 21.2649 2 21.1356 2 21V15C2 14.4477 2.4477 14 3 14 3.5523 14 4 14.4477 4 15V18.5858L13.291 9.292z"></path>
                     </svg>
@@ -216,7 +216,7 @@
                 {{end}}
 
                 {{if (index .Data.Preview.Images 0).Variants.MP4.Source.URL}}
-                <a href="{{(index .Data.Preview.Images 0).Variants.MP4.Source.URL}}" class="l-hovergray" rel="noreferrer noopener nofollow">
+                <a href="{{(index .Data.Preview.Images 0).Variants.MP4.Source.URL|sterilizepath}}" class="l-hovergray" rel="noreferrer noopener nofollow">
                     <svg width="16" height="16" viewBox="0 0 24 24" version="1.1" class="gicon">
                         <path fill-rule="evenodd" d="M21.7092 2.295C21.8041 2.3904 21.8757 2.5001 21.9241 2.6172 21.9727 2.7342 21.9996 2.8625 22 2.997L22 3V9C22 9.5523 21.5523 10 21 10 20.4477 10 20 9.5523 20 9V5.4142L14.7071 10.7071C14 10 14 10 13.2929 9.2929L18.5858 4H15C14.4477 4 14 3.5523 14 3 14 2.4477 14.4477 2 15 2H20.9998C21.2749 2 21.5242 2.1111 21.705 2.2908L21.7092 2.295M14.709 10.707 5.4142 20H9C9.5523 20 10 20.4477 10 21 10 21.5523 9.5523 22 9 22H3.0007L2.997 22C2.743 21.9992 2.4892 21.9023 2.295 21.7092L2.2908 21.705C2.1959 21.6096 2.1243 21.4999 2.0759 21.3828 2.027 21.2649 2 21.1356 2 21V15C2 14.4477 2.4477 14 3 14 3.5523 14 4 14.4477 4 15V18.5858L13.291 9.292z"></path>
                     </svg>
@@ -226,7 +226,7 @@
                 {{end}}
 
                 {{if (index .Data.Preview.Images 0).Source.URL}}
-                    <a href="{{(index .Data.Preview.Images 0).Source.URL}}" class="l-hovergray" rel="noreferrer noopener nofollow">
+                    <a href="{{(index .Data.Preview.Images 0).Source.URL|sterilizepath}}" class="l-hovergray" rel="noreferrer noopener nofollow">
                         <svg width="16" height="16" viewBox="0 0 24 24" version="1.1" class="gicon">
                             <path fill-rule="evenodd" d="M21.7092 2.295C21.8041 2.3904 21.8757 2.5001 21.9241 2.6172 21.9727 2.7342 21.9996 2.8625 22 2.997L22 3V9C22 9.5523 21.5523 10 21 10 20.4477 10 20 9.5523 20 9V5.4142L14.7071 10.7071C14 10 14 10 13.2929 9.2929L18.5858 4H15C14.4477 4 14 3.5523 14 3 14 2.4477 14.4477 2 15 2H20.9998C21.2749 2 21.5242 2.1111 21.705 2.2908L21.7092 2.295M14.709 10.707 5.4142 20H9C9.5523 20 10 20.4477 10 21 10 21.5523 9.5523 22 9 22H3.0007L2.997 22C2.743 21.9992 2.4892 21.9023 2.295 21.7092L2.2908 21.705C2.1959 21.6096 2.1243 21.4999 2.0759 21.3828 2.027 21.2649 2 21.1356 2 21V15C2 14.4477 2.4477 14 3 14 3.5523 14 4 14.4477 4 15V18.5858L13.291 9.292z"></path>
                         </svg>
@@ -236,7 +236,7 @@
                 {{end}}
             {{end}}
             {{if .Data.SecureMedia.RedditVideo.FallbackURL}}
-                <a href="{{.Data.SecureMedia.RedditVideo.FallbackURL}}" class="l-hovergray" rel="noreferrer noopener nofollow">
+                <a href="{{.Data.SecureMedia.RedditVideo.FallbackURL|sterilizepath}}" class="l-hovergray" rel="noreferrer noopener nofollow">
                     <svg width="16" height="16" viewBox="0 0 24 24" version="1.1" class="gicon">
                         <path fill-rule="evenodd" d="M21.7092 2.295C21.8041 2.3904 21.8757 2.5001 21.9241 2.6172 21.9727 2.7342 21.9996 2.8625 22 2.997L22 3V9C22 9.5523 21.5523 10 21 10 20.4477 10 20 9.5523 20 9V5.4142L14.7071 10.7071C14 10 14 10 13.2929 9.2929L18.5858 4H15C14.4477 4 14 3.5523 14 3 14 2.4477 14.4477 2 15 2H20.9998C21.2749 2 21.5242 2.1111 21.705 2.2908L21.7092 2.295M14.709 10.707 5.4142 20H9C9.5523 20 10 20.4477 10 21 10 21.5523 9.5523 22 9 22H3.0007L2.997 22C2.743 21.9992 2.4892 21.9023 2.295 21.7092L2.2908 21.705C2.1959 21.6096 2.1243 21.4999 2.0759 21.3828 2.027 21.2649 2 21.1356 2 21V15C2 14.4477 2.4477 14 3 14 3.5523 14 4 14.4477 4 15V18.5858L13.291 9.292z"></path>
                     </svg>

--- a/src/views/sub.html
+++ b/src/views/sub.html
@@ -51,5 +51,16 @@
     {{if .GalleryNav}}
         <script src="/js/gallerynav.js"></script>
     {{end}}
+
+    {{if .UseAdvMath}}
+        <style>
+            img:not(.malign), video {
+                max-width: clamp(256px, 70vw, 512px);
+            }
+            #posts div.post {
+                width: clamp(180px, 80vw, 720px);
+            }
+        </style>
+    {{end}}
 </body>
 </html>

--- a/src/views/sub.html
+++ b/src/views/sub.html
@@ -10,10 +10,10 @@
 <body>
     {{template "navbar" .}}
     <div class="content">
-        <span style="display:block; padding:15px; background: url({{.SubData.Banner}}) center center/cover no-repeat; height: 192px; {{if and (.SubData.PrimaryColor) (not .SubData.Banner) }} background-color: {{.SubData.PrimaryColor}}; {{end}}"></span>
+        <span style="display:block; padding:15px; background: url({{.SubData.Banner|sterilizepath}}) center center/cover no-repeat; height: 192px; {{if and (.SubData.PrimaryColor) (not .SubData.Banner) }} background-color: {{.SubData.PrimaryColor}}; {{end}}"></span>
         <div class="subinfo">
             <div class="ext">
-                <img src="{{.SubData.CommunityIcon}}" class="img" {{if and (.SubData.PrimaryColor) (not .SubData.CommunityIcon) }} style="background-color: {{.SubData.PrimaryColor}};" {{end}}>
+                <img src="{{.SubData.CommunityIcon|sterilizepath}}" class="img" {{if and (.SubData.PrimaryColor) (not .SubData.CommunityIcon) }} style="background-color: {{.SubData.PrimaryColor}};" {{end}}>
                 <span class="ltext ltype1">{{.SubData.Title}}</span>
                 <span class="ltext ltype2">{{.SubData.DisplayNamePrefixed}} &bullet; {{.SubData.Created|fmtEpochDate}} ({{.SubData.Created|fmtHumanDate}}) &bullet; {{.SubData.ActiveUserCount|fmtHumanComma}} Active Users &bullet; {{.SubData.MemberCount|fmtHumanComma}} Members {{if .SubData.PrimaryColor}} &bullet; <span class="primarycolorcase" style="background-color: {{.SubData.PrimaryColor}};">&nbsp;</span> {{.SubData.PrimaryColor}} Primary color {{end}}</span>
                 <span class="ltext ltype2">{{.SubData.Description}}</span>


### PR DESCRIPTION
# Also...

- Added a config to use clamp (to size posts)
- Bumped github.com/gofiber/fiber/v2 v2.43.0 => v2.44.0
- Use default http client to send requests to JSON endpoints <sub>(as well as add more headers to the request)</sub>
- **Requests are now proxied**
- Added a semi-strict CSP
- Added a no-referrer policy (this does introduce a bug where RedirectBack fails, so I'll call it a feature for now.)
- NoRoute now returns a 404 status instead of 200