### PR TITLE
Fix #38

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/goccy/go-json v0.10.2
 	github.com/gofiber/fiber/v2 v2.44.0
-	github.com/gofiber/helmet/v2 v2.2.25
-	github.com/gofiber/template v1.8.0
+	github.com/gofiber/helmet/v2 v2.2.26
+	github.com/gofiber/template v1.8.1
 	github.com/microcosm-cc/bluemonday v1.0.23
 	github.com/russross/blackfriday/v2 v2.1.0
 )
@@ -27,7 +27,7 @@ require (
 	github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.45.0 // indirect
+	github.com/valyala/fasthttp v1.46.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -132,13 +132,12 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofiber/fiber/v2 v2.43.0/go.mod h1:mpS1ZNE5jU+u+BA4FbM+KKnUzJ4wzTK+FT2tG3tU+6I=
 github.com/gofiber/fiber/v2 v2.44.0 h1:Z90bEvPcJM5GFJnu1py0E1ojoerkyew3iiNJ78MQCM8=
 github.com/gofiber/fiber/v2 v2.44.0/go.mod h1:VTMtb/au8g01iqvHyaCzftuM/xmZgKOZCtFzz6CdV9w=
-github.com/gofiber/helmet/v2 v2.2.25 h1:PC90SBQQ/tzcDUGJtTHAIftdLMa6ylICUCUiM6qzU9s=
-github.com/gofiber/helmet/v2 v2.2.25/go.mod h1:3cn2RTs4wU4QEjwxM8dMwHiZprgJjeIvVGntP16Et1Y=
-github.com/gofiber/template v1.8.0 h1:jOn9RhxYO7rHTHGLNRpYfDoVm8b5GH/dtl15ZT5NifE=
-github.com/gofiber/template v1.8.0/go.mod h1:jf2w+ioGUS5swf5C/VK+FyE+DI19uz+vXHCX/TIAxIk=
+github.com/gofiber/helmet/v2 v2.2.26 h1:KreQVUpCIGppPQ6Yt8qQMaIR4fVXMnvBdsda0dJSsO8=
+github.com/gofiber/helmet/v2 v2.2.26/go.mod h1:XE0DF4cgf0M5xIt7qyAK5zOi8jJblhxfSDv9DAmEEQo=
+github.com/gofiber/template v1.8.1 h1:KLnNtXqH3LTzquU0NsLMqX3YGd3pD562UhSNaIca5HI=
+github.com/gofiber/template v1.8.1/go.mod h1:+2x8bRo2TAXnqp0RUN2MdyKshUi+BulPoUCOHstFLqE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -287,7 +286,6 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
@@ -376,8 +374,9 @@ github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkC
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.45.0 h1:zPkkzpIn8tdHZUrVa6PzYd0i5verqiPSkgTd3bSUcpA=
 github.com/valyala/fasthttp v1.45.0/go.mod h1:k2zXd82h/7UZc3VOdJ2WaUqt1uZ/XpXAfE9i+HBC3lA=
+github.com/valyala/fasthttp v1.46.0 h1:6ZRhrFg8zBXTRYY6vdzbFhqsBd7FVv123pV2m9V87U4=
+github.com/valyala/fasthttp v1.46.0/go.mod h1:k2zXd82h/7UZc3VOdJ2WaUqt1uZ/XpXAfE9i+HBC3lA=
 github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVSA8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/yosssi/ace v0.0.5/go.mod h1:ALfIzm2vT7t5ZE7uoIZqF3TQ7SAOyupFZnkrF5id+K0=

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -39,6 +39,7 @@ const (
 	GalleryCookie = "GalleryNav"
 	USRCCookie    = "TrustUSrc"
 	MathCookie    = "UseAdvMath"
+	AwardCookie   = "DisableAwards"
 
 	JSCookieValue      = "js_enabled"
 	INFCookieValue     = "infscroll_enabled"
@@ -47,6 +48,7 @@ const (
 	GalleryCookieValue = "gallery_navigation"
 	USRCCookieValue    = "trust_unknownsources"
 	MathCookieValue    = "advanced_math"
+	AwardCookieValue   = "disable_awards"
 )
 
 var (
@@ -60,6 +62,7 @@ var (
 		"EnableGalleryNav": GalleryCookieValue,
 		"TrustUnknownSrc":  USRCCookieValue,
 		"UseAdvancedMath":  MathCookieValue,
+		"BlockAwards":      AwardCookieValue,
 	}
 
 	ValidImageExts = map[string]bool{
@@ -162,6 +165,7 @@ func StartServer() {
 			gallerynav := ctx.Cookies(GalleryCookieValue)
 			trustusrc := ctx.Cookies(USRCCookieValue)
 			advmath := ctx.Cookies(MathCookieValue)
+			disableawards := ctx.Cookies(AwardCookieValue)
 
 			ctx.Bind(fiber.Map{ //nolint:errcheck,gosec,revive // ctx.Bind always returns nil
 				JSCookie:      jsenabled == "1",
@@ -170,6 +174,7 @@ func StartServer() {
 				GalleryCookie: gallerynav == "1",
 				USRCCookie:    trustusrc == "1",
 				MathCookie:    advmath == "1",
+				AwardCookie:   disableawards == "1",
 			})
 
 			return ctx.Next()

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -65,11 +65,11 @@ var (
 		"BlockAwards":      AwardCookieValue,
 	}
 
-	ValidImageExts = map[string]bool{
-		".gif":  true,
-		".png":  true,
-		".jpg":  true,
-		".jpeg": true,
+	ValidImageExts = map[string]struct{}{
+		".gif":  {},
+		".png":  {},
+		".jpg":  {},
+		".jpeg": {},
 	}
 
 	RewritePath = map[string]string{
@@ -122,7 +122,7 @@ func StartServer() {
 			return template.HTML(sHTML) //nolint:gosec,revive // bluemonday sanitizes this.
 		},
 		"qualifiesAsImg": func(input string) bool {
-			return ValidImageExts[filepath.Ext(input)]
+			return ValidImageExts[filepath.Ext(input)] == struct{}{}
 		},
 		"fmtEpochDate": func(input float64) string {
 			return time.Unix(int64(input), 0).Format("Created Jan 02, 2006")

--- a/src/views/config.html
+++ b/src/views/config.html
@@ -96,6 +96,18 @@
             </pre>
 
             <label>
+                <input type="checkbox" name="BlockAwards" {{if .DisableAwards}} checked {{end}}>
+                <input type="hidden" name="BlockAwards" value="off">
+                Disable Awards
+            </label>
+            <pre>
+                Enabling this config will not load any awards
+                Including comment achievements, and starred comments
+                Useful if there is a LOT of awards on a post (and it may be distracting)
+                Can also speed up load times and uses less data
+            </pre>
+
+            <label>
                 Preferred Resolution
                 <select name="PrefRes">
                     <!-- dear lord -->

--- a/src/views/posts.html
+++ b/src/views/posts.html
@@ -37,7 +37,7 @@
                     </svg>
                 {{end}}
             </span>
-            {{if .Data.Awardings}}
+            {{if and (.Data.Awardings) (not $.DisableAwards)}}
             <div style="display: inline;">
                 {{range .Data.Awardings}}
                     {{if contains .AwardSubType "MODERATOR"}}


### PR DESCRIPTION
# Also...
- Updated dependencies
  - Bump `github.com/gofiber/helmet/v2 v2.2.25` => `v2.2.26`
  - Bump `github.com/gofiber/template v1.8.0` => `v1.8.1`
  - Bump `github.com/valyala/fasthttp v1.45.0` => `v1.46.0`
- Use `go 1.20` in go.mod instead of `go 1.19`
- Optimized qualifiesAsImg && ValidImageExts
  - instead of using bool, we now use struct{} (no memory allocation)
- **Added an option to disable awards. | This fixes #38**